### PR TITLE
feat: add support for o1 models

### DIFF
--- a/claude.go
+++ b/claude.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -44,7 +45,17 @@ func NewClaude() (*Codec, error) {
 			return nil, bErr
 		}
 
-		mergeableRanks[string(t)] = uint(i * offset)
+		if offset < 0 {
+			return nil, fmt.Errorf("negative value not allowed: %d", offset)
+		}
+
+		product := i * offset
+
+		if i < 0 || product < 0 || product > (1<<32-1) {
+			return nil, fmt.Errorf("integer overflow in calculation: %d * %d", i, offset)
+		}
+
+		mergeableRanks[string(t)] = uint(product)
 	}
 
 	return &Codec{

--- a/tiktoken.go
+++ b/tiktoken.go
@@ -19,7 +19,9 @@ const (
 
 // ModelPrefixToEncoding maps model prefixes to encodings.
 var ModelPrefixToEncoding = map[string]string{
+	"o1-": O200kBase,
 	// chat
+	"chatgpt-4o-":    O200kBase,
 	"gpt-4o-":        O200kBase,  // e.g., gpt-4o-2024-05-13
 	"gpt-4-":         CL100kBase, // e.g., gpt-4-0314, etc., plus gpt-4-32k
 	"gpt-3.5-turbo-": CL100kBase, // e.g, gpt-3.5-turbo-0301, -0401, etc.

--- a/tiktoken_test.go
+++ b/tiktoken_test.go
@@ -45,6 +45,12 @@ func TestNewEncodingForModel(t *testing.T) {
 			expectedError:  nil,
 		},
 		{
+			name:           "o200k_base",
+			model:          "o1-mini",
+			expectedResult: O200kBase,
+			expectedError:  nil,
+		},
+		{
 			name:           "Model with Prefix",
 			model:          "gpt-4-",
 			expectedResult: CL100kBase,


### PR DESCRIPTION
📜 Lore

Adding support to `o1-` models

🗝️ Key Changes

🛡️ Main Quests

- [x] add support for `o1-` models
- [x] new test for `o1-`
- [x] fix lint errors:
```run golangci-lint
  Running [/home/runner/golangci-lint-1.63.4-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  Error: Error return value is not checked (errcheck)
  ::high file=claude.go,line=47,col=35::G115: integer overflow conversion int -> uint (gosec)
  ::high file=codec.go,line=80,col=[23](https://github.com/hupe1980/go-tiktoken/actions/runs/13061604899/job/36445649503?pr=5#step:4:25)::G115: integer overflow conversion int -> uint (gosec)
  ::high file=codec.go,line=99,col=23::G115: integer overflow conversion int -> uint (gosec)```